### PR TITLE
Support S3-compatible services that don't rely on X-Amz-Security-Token

### DIFF
--- a/src/signed.nim
+++ b/src/signed.nim
@@ -65,9 +65,10 @@ proc s3SignedUrl*(awsCreds: AwsCreds, bucketHost, key: string, httpMethod=HttpGe
               "X-Amz-Credential": accessKey & "/" & scope,
               "X-Amz-Date": datetime,
               "X-Amz-Expires": expireSec,
-              "X-Amz-Security-Token": tokenKey,
               # "X-Amz-SignedHeaders": "host"
             }
+  if tokenKey != "":
+    query["X-Amz-Security-Token"] = newJString(tokenKey)
 
   if contentName != "":
     jsonUpdate(query, %*{"response-content-disposition": "attachment; filename=\"" & contentName & "\""})


### PR DESCRIPTION
The DigitalOcean S3 equivalent (Spaces) does not use the X-Amz-Security-Token header. This change makes the session/security token optional.