### PR TITLE
DigitalOcean doesn't accept chunked encodings

### DIFF
--- a/src/api.nim
+++ b/src/api.nim
@@ -179,10 +179,7 @@ proc s3GetObjectIs2xx*(creds: AwsCreds, bucketHost, key, downloadPath: string): 
 proc s3PutObject*(client: AsyncHttpClient, creds: AwsCreds, bucketHost, key, localPath: string): Future[AsyncResponse]  {.async.} =
   ## AWS S3 API - PutObject
   ##
-  let mimes = newMimetypes()
-  var data = newMultipartData()
-  data.addFiles({"file": localPath}, mimeDb = mimes)
-  result = await client.put(s3SignedUrl(creds, bucketHost, key, httpMethod=HttpPut), multipart=data)
+  result = await client.put(s3SignedUrl(creds, bucketHost, key, httpMethod=HttpPut), body = readFile(localPath))
 
 
 proc s3PutObjectIs2xx*(creds: AwsCreds, bucketHost, key, localPath: string, deleteLocalFileAfter=true): Future[bool] {.async.} =

--- a/src/signed.nim
+++ b/src/signed.nim
@@ -65,9 +65,10 @@ proc s3SignedUrl*(awsCreds: AwsCreds, bucketHost, key: string, httpMethod=HttpGe
               "X-Amz-Credential": accessKey & "/" & scope,
               "X-Amz-Date": datetime,
               "X-Amz-Expires": expireSec,
-              "X-Amz-Security-Token": tokenKey,
               # "X-Amz-SignedHeaders": "host"
             }
+  if tokenKey != "":
+    query["X-Amz-Security-Token"] = newJString(tokenKey)
 
   if contentName != "":
     jsonUpdate(query, %*{"response-content-disposition": "attachment; filename=\"" & contentName & "\""})


### PR DESCRIPTION
Does AWS PutObject accept chunked encodings?  When I uploaded a file using the current version of nim_awsS3, it wrote the entire request body to the file:

```
--4292486321577947087
Content-Disposition: form-data; name="file"; filename="tmp"
Content-Type: 

This is data
--4292486321577947087--
```

Rather than just the data `This is data`. With this PR, now PutObject just write `This is data`.

However, I don't have an AWS S3 bucket to test with.